### PR TITLE
Feat: Answer Stub Data 이용한 Controller 및 Dto, Entity 구현

### DIFF
--- a/modudogcat/src/main/java/com/k5/modudogcat/domain/anwser/controller/AnswerController.java
+++ b/modudogcat/src/main/java/com/k5/modudogcat/domain/anwser/controller/AnswerController.java
@@ -19,12 +19,14 @@ import java.util.List;
 @AllArgsConstructor
 public class AnswerController {
 
+    //QnA 답변 작성
     @PostMapping
     public ResponseEntity postAnswer (@RequestBody AnswerDto.Post post) {
 
         return ResponseEntity.created(URI.create("/sellers/answers/1")).build();
     }
 
+    //QnA 답변 조회
     @GetMapping("/{answer-id}")
     public ResponseEntity<AnswerDto.Response> getAnswer (@PathVariable("answer-id") @Positive Long answerId) {
 
@@ -34,6 +36,7 @@ public class AnswerController {
 
     }
 
+    //QnA 판매자의 답변 목록
     @GetMapping
     public ResponseEntity getAnswers(Pageable pageable) {
 

--- a/modudogcat/src/main/java/com/k5/modudogcat/domain/anwser/dto/AnswerDto.java
+++ b/modudogcat/src/main/java/com/k5/modudogcat/domain/anwser/dto/AnswerDto.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class AnswerDto {
-
     @Getter
     @Setter
     @AllArgsConstructor

--- a/modudogcat/src/main/java/com/k5/modudogcat/domain/anwser/entity/Answer.java
+++ b/modudogcat/src/main/java/com/k5/modudogcat/domain/anwser/entity/Answer.java
@@ -4,7 +4,6 @@ import com.k5.modudogcat.audit.Auditable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
 import javax.persistence.*;
 
 @Entity


### PR DESCRIPTION
# Pull Request
Feat: Answer Stub Data 이용한 Controller 및 Dto, Entity 구현

<br>

## Body
1. feat : Answer entity 및 Controller 구현(Stub Data)
    -  Answer entity 구현
    -  AnswerDto 구현
    - AnswerController 구현

2. test : Rest Docs API 문서 생성 위한 AnswerControllerTest 구현(Stub Data)
    - Stub Data 이용한 AnswerControllerTest 구현

3. docs : Rest Docs를 활용한 Answer API 문서 생성
    - index.adoc 구현
    - index.html 생성

4. feat : Answer Stub Data 이용한 Controller 및 Dto, Entity 구현
    - 브랜치 생성 및 새로운 원격 브랜치에 푸쉬하기 위한 커밋
    
<br>
## Footer

Resolves: #SEL01_PRODUCT02
Related to: #ORD01_PRODUCT05

<br>
